### PR TITLE
Yaml serialization for InputTriggerDescription.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.yaml</groupId>
+			<artifactId>snakeyaml</artifactId>
+			<version>1.8</version>
+		</dependency>
 	</dependencies>
 
 	<developers>

--- a/src/main/java/bdv/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/bdv/behaviour/io/InputTriggerConfig.java
@@ -34,19 +34,23 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 
 		for ( final InputTriggerDescription mapping : keyMappings )
 		{
-			final InputTrigger trigger = InputTrigger.getFromString( mapping.getTrigger() );
 			final String behaviour = mapping.getAction();
 			final HashSet< String > contexts = new HashSet< String >();
 			contexts.addAll( Arrays.asList( mapping.getContexts() ) );
-			final Input input = new Input( trigger, behaviour, contexts );
-
-			Set< Input > inputs = actionToInputsMap.get( input.behaviour );
-			if ( inputs == null )
+			final String[] triggers = mapping.getTriggers();
+			for ( final String triggerStr : triggers )
 			{
-				inputs = new HashSet<>();
-				actionToInputsMap.put( input.behaviour, inputs );
+				final InputTrigger trigger = InputTrigger.getFromString( triggerStr );
+				final Input input = new Input( trigger, behaviour, contexts );
+
+				Set< Input > inputs = actionToInputsMap.get( input.behaviour );
+				if ( inputs == null )
+				{
+					inputs = new HashSet< >();
+					actionToInputsMap.put( input.behaviour, inputs );
+				}
+				inputs.add( input );
 			}
-			inputs.add( input );
 		}
 	}
 
@@ -245,7 +249,7 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 
 		InputTriggerDescription getDescription()
 		{
-			return new InputTriggerDescription( trigger.toString(), behaviour, contexts.toArray( new String[ 0 ] ) );
+			return new InputTriggerDescription( new String[] { trigger.toString() }, behaviour, contexts.toArray( new String[ 0 ] ) );
 		}
 	}
 

--- a/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
+++ b/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
@@ -1,9 +1,5 @@
 package bdv.behaviour.io;
 
-import javax.swing.Action;
-
-import bdv.behaviour.Behaviour;
-import bdv.behaviour.InputTrigger;
 
 /**
  * IO record describing the mapping of one {@link InputTrigger} to an
@@ -16,17 +12,17 @@ public class InputTriggerDescription
 	/**
 	 * String representation of the {@link InputTrigger}.
 	 */
-	private final String trigger;
+	private String trigger;
 
 	/**
 	 * Key of the {@link Action} or {@link Behaviour}.
 	 */
-	private final String action;
+	private String action;
 
 	/**
 	 * A list of contexts in which this mapping is active.
 	 */
-	private final String[] contexts;
+	private String[] contexts;
 
 	public InputTriggerDescription(
 			final String trigger,
@@ -38,17 +34,20 @@ public class InputTriggerDescription
 		this.contexts = contexts;
 	}
 
+	public InputTriggerDescription()
+	{}
+
 	@Override
 	public String toString()
 	{
 		String s =
 				"( trigger  = \"" + trigger +"\"\n" +
 				"  action   = \"" + action +"\"\n" +
-				"  contexts = {";
+						"  contexts = [";
 		if ( contexts != null )
 			for ( int i = 0; i < contexts.length; ++i )
 				s += "\"" + contexts[ i ] + "\"" + ( i == contexts.length - 1 ? "" : ", " );
-		s += "} )\n";
+		s += "] )\n";
 		return s;
 	}
 
@@ -65,5 +64,20 @@ public class InputTriggerDescription
 	public String[] getContexts()
 	{
 		return contexts;
+	}
+
+	public void setTrigger( final String trigger )
+	{
+		this.trigger = trigger;
+	}
+
+	public void setAction( final String action )
+	{
+		this.action = action;
+	}
+
+	public void setContexts( final String[] contexts )
+	{
+		this.contexts = contexts;
 	}
 }

--- a/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
+++ b/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
@@ -31,7 +31,7 @@ public class InputTriggerDescription
 	{
 		this.trigger = trigger;
 		this.action = action;
-		this.contexts = contexts;
+		setContexts( contexts );
 	}
 
 	public InputTriggerDescription()
@@ -78,6 +78,9 @@ public class InputTriggerDescription
 
 	public void setContexts( final String[] contexts )
 	{
-		this.contexts = contexts;
+		if ( contexts == null || ( contexts.length == 1 && contexts[ 0 ].isEmpty() ) )
+			this.contexts = new String[ 0 ];
+		else
+			this.contexts = contexts;
 	}
 }

--- a/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
+++ b/src/main/java/bdv/behaviour/io/InputTriggerDescription.java
@@ -12,7 +12,7 @@ public class InputTriggerDescription
 	/**
 	 * String representation of the {@link InputTrigger}.
 	 */
-	private String trigger;
+	private String[] triggers;
 
 	/**
 	 * Key of the {@link Action} or {@link Behaviour}.
@@ -25,11 +25,11 @@ public class InputTriggerDescription
 	private String[] contexts;
 
 	public InputTriggerDescription(
-			final String trigger,
+			final String[] trigger,
 			final String action,
 			final String... contexts )
 	{
-		this.trigger = trigger;
+		this.triggers = trigger;
 		this.action = action;
 		setContexts( contexts );
 	}
@@ -40,10 +40,15 @@ public class InputTriggerDescription
 	@Override
 	public String toString()
 	{
-		String s =
-				"( trigger  = \"" + trigger +"\"\n" +
-				"  action   = \"" + action +"\"\n" +
-						"  contexts = [";
+		String s = "( trigger  = [";
+		if ( triggers != null )
+			for ( int i = 0; i < triggers.length; ++i )
+				s += "\"" + triggers[ i ] + "\"" + ( i == triggers.length - 1 ? "" : ", " );
+		s += "]\n";
+
+		s += "  action   = \"" + action + "\"\n";
+
+		s += "  contexts = [";
 		if ( contexts != null )
 			for ( int i = 0; i < contexts.length; ++i )
 				s += "\"" + contexts[ i ] + "\"" + ( i == contexts.length - 1 ? "" : ", " );
@@ -51,9 +56,9 @@ public class InputTriggerDescription
 		return s;
 	}
 
-	public String getTrigger()
+	public String[] getTriggers()
 	{
-		return trigger;
+		return triggers;
 	}
 
 	public String getAction()
@@ -66,9 +71,9 @@ public class InputTriggerDescription
 		return contexts;
 	}
 
-	public void setTrigger( final String trigger )
+	public void setTriggers( final String[] triggers )
 	{
-		this.trigger = trigger;
+		this.triggers = triggers;
 	}
 
 	public void setAction( final String action )

--- a/src/main/java/bdv/behaviour/io/InputTriggerDescriptionsBuilder.java
+++ b/src/main/java/bdv/behaviour/io/InputTriggerDescriptionsBuilder.java
@@ -35,7 +35,7 @@ public class InputTriggerDescriptionsBuilder
 			for ( final Input input : inputs )
 			{
 				final InputTriggerDescription desc = new InputTriggerDescription(
-						input.trigger.toString(),
+						new String[] { input.trigger.toString() },
 						input.behaviour,
 						input.contexts.toArray( new String[ 0 ] ) );
 				descs.add( desc );

--- a/src/main/java/bdv/behaviour/io/yaml/YamlConfigIO.java
+++ b/src/main/java/bdv/behaviour/io/yaml/YamlConfigIO.java
@@ -147,7 +147,7 @@ public class YamlConfigIO
 						System.err.println( "[YamlConfigIO] Missing contexts definition for mapping:\n" + mapping + "- ignored." );
 						continue;
 					}
-					if ( null == mapping.getTrigger() )
+						if ( null == mapping.getTriggers() )
 					{
 						System.err.println( "[YamlConfigIO] Missing trigger definition for mapping:\n" + mapping + "- ignored." );
 						continue;

--- a/src/main/java/bdv/behaviour/io/yaml/YamlConfigIO.java
+++ b/src/main/java/bdv/behaviour/io/yaml/YamlConfigIO.java
@@ -1,0 +1,203 @@
+package bdv.behaviour.io.yaml;
+
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.scanner.ScannerException;
+
+import bdv.behaviour.io.InputTriggerDescription;
+
+/**
+ * Facilities to serialize / de-serialize {@link InputTriggerDescription}s to a
+ * YAML file.
+ * <p>
+ * The YAML file will have this shape:
+ *
+ * <pre>
+ * --- !mapping
+ * action: ts select vertex
+ * contexts: [trackscheme]
+ * trigger: button1
+ * --- !mapping
+ * action: ts select edge
+ * contexts: [bdv, trackscheme]
+ * trigger: button2
+ * --- !mapping
+ * action: navigate
+ * contexts: [bdv, trackscheme]
+ * trigger: A
+ * --- !mapping
+ * action: sleep
+ * contexts: []
+ * trigger: B
+ * </pre>
+ *
+ * @author Jean-Yves Tinevez.
+ *
+ */
+public class YamlConfigIO
+{
+
+	private static final Tag tag = new Tag( "!mapping" );
+
+	/**
+	 * Returns a new, properly configured YAML instance, able to write and read
+	 * key mappings.
+	 *
+	 * @return a new {@link Yaml} instance.
+	 */
+	private static final Yaml getYaml()
+	{
+		final Representer representer = new Representer();
+		representer.addClassTag( InputTriggerDescription.class, tag );
+
+		final Constructor constructor = new Constructor();
+		constructor.addTypeDescription( new TypeDescription( InputTriggerDescription.class, tag ) );
+
+		final DumperOptions options = new DumperOptions();
+		options.setExplicitStart( true );
+
+		final Yaml yaml = new Yaml( constructor, representer, options );
+		return yaml;
+	}
+
+	/**
+	 * Writes the specified {@link InputTriggerDescription}s on the specified
+	 * writer.
+	 * <p>
+	 * If the specified writer is configured to append to the stream, this method
+	 * can be used to append configuration items to a configuration file created elsewhere.
+	 *
+	 * @param descriptions
+	 *            an iterator over the mapping description to write.
+	 * @param writer
+	 *            the writer. Is not closed after this method returns.
+	 */
+	public static void write( final Iterator< InputTriggerDescription > descriptions, final Writer writer )
+	{
+		final Yaml yaml = getYaml();
+		yaml.dumpAll( descriptions, writer );
+	}
+
+	/**
+	 * Writes the specified {@link InputTriggerDescription}s on the specified
+	 * file.
+	 *
+	 * @param descriptions
+	 *            an iterator over the mapping description to write.
+	 * @param fileName
+	 *            the system-dependent filename.
+	 * @throws IOException
+	 *             if the named file exists but is a directory rather than a
+	 *             regular file, does not exist but cannot be created, or cannot
+	 *             be opened for any other reason
+	 */
+	public static void write( final Iterator< InputTriggerDescription > descriptions, final String fileName ) throws IOException
+	{
+		final FileWriter writer = new FileWriter( fileName );
+		write( descriptions, writer );
+		writer.close();
+	}
+
+	/**
+	 * Reads from the specified reader instance and returns the list of
+	 * serialized {@link InputTriggerDescription}s that are found in the input
+	 * stream.
+	 *
+	 * @param reader
+	 *            the reader to read from. Is not closed after this method
+	 *            returns.
+	 * @return a new list containing the {@link InputTriggerDescription}s found in
+	 *         the stream. Other objects are ignored.
+	 */
+	public static List< InputTriggerDescription > read( final Reader reader )
+	{
+		final Yaml yaml = getYaml();
+		final Iterator< Object > it = yaml.loadAll( reader ).iterator();
+		final List< InputTriggerDescription > descriptions = new ArrayList< InputTriggerDescription >();
+		try
+		{
+			while ( it.hasNext() )
+			{
+				try
+				{
+					final Object obj = it.next();
+					if ( obj instanceof InputTriggerDescription )
+					{
+						final InputTriggerDescription mapping = ( InputTriggerDescription ) obj;
+						if ( null == mapping.getAction())
+						{
+							System.err.println( "[YamlConfigIO] Missing action definition for mapping:\n" + mapping + "- ignored." );
+							continue;
+						}
+						if ( null == mapping.getContexts() )
+						{
+							System.err.println( "[YamlConfigIO] Missing contexts definition for mapping:\n" + mapping + "- ignored." );
+							continue;
+						}
+						if ( null == mapping.getTrigger() )
+						{
+							System.err.println( "[YamlConfigIO] Missing trigger definition for mapping:\n" + mapping + "- ignored." );
+							continue;
+						}
+
+						descriptions.add( mapping );
+					}
+				}
+				catch ( final ConstructorException ce )
+				{
+					System.err.println( "[YamlConfigIO] Unkown element at line " + ( ce.getProblemMark().getLine() + 1 ) + ", ignored:" );
+					System.err.println( ce.getProblemMark().get_snippet() );
+				}
+				catch ( final ScannerException se )
+				{
+					System.err.println( "[YamlConfigIO] Unable to read element at line " + ( se.getProblemMark().getLine() + 1 ) + ", ignored:" );
+					System.err.println( se.getProblemMark().get_snippet() );
+				}
+			}
+		}
+		catch ( final ScannerException se )
+		{
+			System.err.println( "[YamlConfigIO] Unable to scan file for value around line " + ( se.getProblemMark().getLine() + 1 ) + ", aborting:" );
+			System.err.println( se.getProblemMark().get_snippet() );
+		}
+		return descriptions;
+	}
+
+	/**
+	 * Reads from the specified file and returns the list of serialized
+	 * {@link InputTriggerDescription}s that are found in the file.
+	 *
+	 * @param fileName
+	 *            the system-dependent filename.
+	 * @return a new list containing the {@link InputTriggerDescription}s found in
+	 *         the file. Other objects are ignored.
+	 * @throws IOException
+	 *             if an I/O error occurs, if the named file does not exist, is
+	 *             a directory rather than a regular file, or for some other
+	 *             reason cannot be opened for reading.
+	 */
+	public static List< InputTriggerDescription > read( final String fileName ) throws IOException
+	{
+		final FileReader reader = new FileReader( fileName );
+		final List< InputTriggerDescription > descriptions = read( reader );
+		reader.close();
+		return descriptions;
+	}
+
+	private YamlConfigIO()
+	{}
+}

--- a/src/test/java/bdv/behaviour/io/json/JSonInteractiveTest.java
+++ b/src/test/java/bdv/behaviour/io/json/JSonInteractiveTest.java
@@ -30,10 +30,10 @@ public class JSonInteractiveTest
 		System.out.println( "\nWriting to file " + fileName );
 
 		final ArrayList< InputTriggerDescription > keyMappings = new ArrayList< InputTriggerDescription >();
-		keyMappings.add( new InputTriggerDescription( "button1", "ts select vertex", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "button2", "ts select edge", "bdv", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "A", "navigate", "bdv", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "B", "sleep", "" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "button1" }, "ts select vertex", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "button2" }, "ts select edge", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "A" }, "navigate", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "B" }, "sleep", "" ) );
 		JsonConfigIO.write( keyMappings, file.getAbsolutePath() );
 
 		System.out.println( "\nContent of file:" );

--- a/src/test/java/bdv/behaviour/io/json/JSonInteractiveTest.java
+++ b/src/test/java/bdv/behaviour/io/json/JSonInteractiveTest.java
@@ -1,0 +1,60 @@
+package bdv.behaviour.io.json;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import bdv.behaviour.io.InputTriggerDescription;
+
+public class JSonInteractiveTest
+{
+	public static void main( final String[] args ) throws IOException
+	{
+		final String fileName = "jsontest.txt";
+
+		final File file = new File( fileName );
+		if ( file.exists() )
+		{
+			System.out.println( "File " + file + " found. Reading from it." );
+			final List< InputTriggerDescription > list = JsonConfigIO.read( fileName );
+			System.out.println( list );
+		}
+		
+		/*
+		 * TEST WRITE
+		 */
+
+		System.out.println( "\nWriting to file " + fileName );
+
+		final ArrayList< InputTriggerDescription > keyMappings = new ArrayList< InputTriggerDescription >();
+		keyMappings.add( new InputTriggerDescription( "button1", "ts select vertex", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "button2", "ts select edge", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "A", "navigate", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "B", "sleep", "" ) );
+		JsonConfigIO.write( keyMappings, file.getAbsolutePath() );
+
+		System.out.println( "\nContent of file:" );
+
+		final BufferedReader reader =  new BufferedReader(new FileReader( fileName ));
+		String line = reader.readLine();
+		while ( line != null )
+		{
+			System.out.println( line );
+			line = reader.readLine();
+		}
+		reader.close();
+
+		/*
+		 * TEST READ
+		 */
+		
+		System.out.println( "\nReading from file:" );
+		final List< InputTriggerDescription > list = JsonConfigIO.read( fileName );
+		System.out.println( list );
+		
+	}
+
+}

--- a/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
+++ b/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
@@ -1,0 +1,121 @@
+package bdv.behaviour.io.yaml;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import bdv.behaviour.io.InputTriggerDescription;
+
+public class YamlInteractiveTest
+{
+	public static void main( final String[] args ) throws IOException
+	{
+		final String fileName = "yamltest.txt";
+
+		final File file = new File( fileName );
+		if ( file.exists() )
+		{
+			System.out.println( "File " + file + " found. Reading from it." );
+			final List< InputTriggerDescription > list = YamlConfigIO.read( fileName );
+			System.out.println( list );
+		}
+		
+		/*
+		 * TEST WRITE
+		 */
+
+		System.out.println( "\nWriting to file " + fileName );
+
+		final ArrayList< InputTriggerDescription > keyMappings = new ArrayList< InputTriggerDescription >();
+		keyMappings.add( new InputTriggerDescription( "button1", "ts select vertex", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "button2", "ts select edge", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "A", "navigate", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( "B", "sleep", "" ) );
+		YamlConfigIO.write( keyMappings.iterator(), "yamltest.txt" );
+
+		System.out.println( "\nContent of file:" );
+
+		BufferedReader reader =  new BufferedReader(new FileReader( fileName ));
+		String line = reader.readLine();
+		while ( line != null )
+		{
+			System.out.println( line );
+			line = reader.readLine();
+		}
+		reader.close();
+
+		/*
+		 * TEST APPEND
+		 */
+
+		System.out.println("\nAppending to file " + fileName);
+		
+		final ArrayList< InputTriggerDescription > keyMappings2 = new ArrayList< InputTriggerDescription >();
+		keyMappings2.add( new InputTriggerDescription( "ctrl X", "cut", "" ) );
+		keyMappings2.add( new InputTriggerDescription( "ctrl V", "paste", "" ) );
+		FileWriter writer = new FileWriter( fileName, true );
+		YamlConfigIO.write( keyMappings2.iterator(), writer );
+		writer.close();
+		
+
+		System.out.println( "\nContent of file:" );
+		reader =  new BufferedReader(new FileReader( fileName ));
+		line = reader.readLine();
+		while ( line != null )
+		{
+			System.out.println( line );
+			line = reader.readLine();
+		}
+		reader.close();
+
+		/*
+		 * TEST READ
+		 */
+		
+		System.out.println( "\nReading from file:" );
+		List< InputTriggerDescription > list = YamlConfigIO.read( fileName );
+		System.out.println( list );
+		
+		/*
+		 * TEST HETEROGENOUS DATA
+		 */
+		
+		System.out.println("\nHeterogeneous data.");
+		
+		writer = new FileWriter( fileName, true );
+		
+		// Write a tag that is not handled
+		writer.write( "--- !display\n" );
+		writer.write( "brightness: 100\n" );
+		writer.write( "contrast: 50\n" );
+		
+		// Write a tag with a mistake
+		writer.write( "--- !mapping\n" );
+		writer.write( "acton: paste\n");
+		writer.write( "contexts: []\n" );
+		writer.write( "key: ctrl C\n");
+		
+		// Write a tag with a serious problem
+		writer.write( "--- !mapping\n" );
+		writer.write( "action: pastecontexts: []\n" );
+		writer.write( "key: ctrl C\n");
+
+		// The write something legit.
+		writer.write( "--- !mapping\n" );
+		writer.write( "action: zap2\n");
+		writer.write( "contexts: []\n" );
+		writer.write( "key: Z2\n");
+		
+		writer.close();
+		
+		System.out.println( "\nReading from file:" );
+		list = YamlConfigIO.read( fileName );
+		System.out.println( list );
+		
+	}
+
+}

--- a/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
+++ b/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
@@ -35,36 +35,12 @@ public class YamlInteractiveTest
 		keyMappings.add( new InputTriggerDescription( "button2", "ts select edge", "bdv", "trackscheme" ) );
 		keyMappings.add( new InputTriggerDescription( "A", "navigate", "bdv", "trackscheme" ) );
 		keyMappings.add( new InputTriggerDescription( "B", "sleep", "" ) );
-		YamlConfigIO.write( keyMappings.iterator(), "yamltest.txt" );
+		YamlConfigIO.write( keyMappings, "yamltest.txt" );
 
 		System.out.println( "\nContent of file:" );
 
-		BufferedReader reader =  new BufferedReader(new FileReader( fileName ));
+		final BufferedReader reader =  new BufferedReader(new FileReader( fileName ));
 		String line = reader.readLine();
-		while ( line != null )
-		{
-			System.out.println( line );
-			line = reader.readLine();
-		}
-		reader.close();
-
-		/*
-		 * TEST APPEND
-		 */
-
-		System.out.println("\nAppending to file " + fileName);
-		
-		final ArrayList< InputTriggerDescription > keyMappings2 = new ArrayList< InputTriggerDescription >();
-		keyMappings2.add( new InputTriggerDescription( "ctrl X", "cut", "" ) );
-		keyMappings2.add( new InputTriggerDescription( "ctrl V", "paste", "" ) );
-		FileWriter writer = new FileWriter( fileName, true );
-		YamlConfigIO.write( keyMappings2.iterator(), writer );
-		writer.close();
-		
-
-		System.out.println( "\nContent of file:" );
-		reader =  new BufferedReader(new FileReader( fileName ));
-		line = reader.readLine();
 		while ( line != null )
 		{
 			System.out.println( line );
@@ -84,32 +60,32 @@ public class YamlInteractiveTest
 		 * TEST HETEROGENOUS DATA
 		 */
 		
-		System.out.println("\nHeterogeneous data.");
+		System.out.println( "\nMalformed data." );
 		
-		writer = new FileWriter( fileName, true );
-		
-		// Write a tag that is not handled
-		writer.write( "--- !display\n" );
-		writer.write( "brightness: 100\n" );
-		writer.write( "contrast: 50\n" );
+		final FileWriter writer = new FileWriter( fileName, false );
 		
 		// Write a tag with a mistake
-		writer.write( "--- !mapping\n" );
+		writer.write( "- !mapping\n" );
 		writer.write( "acton: paste\n");
 		writer.write( "contexts: []\n" );
 		writer.write( "key: ctrl C\n");
 		
 		// Write a tag with a serious problem
-		writer.write( "--- !mapping\n" );
+		writer.write( "- !mapping\n" );
 		writer.write( "action: pastecontexts: []\n" );
 		writer.write( "key: ctrl C\n");
 
 		// The write something legit.
-		writer.write( "--- !mapping\n" );
+		writer.write( "- !mapping\n" );
 		writer.write( "action: zap2\n");
 		writer.write( "contexts: []\n" );
 		writer.write( "key: Z2\n");
 		
+		// Write a tag that is not handled
+		writer.write( "---\n- !display\n" );
+		writer.write( "brightness: 100\n" );
+		writer.write( "contrast: 50\n" );
+
 		writer.close();
 		
 		System.out.println( "\nReading from file:" );

--- a/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
+++ b/src/test/java/bdv/behaviour/io/yaml/YamlInteractiveTest.java
@@ -31,10 +31,10 @@ public class YamlInteractiveTest
 		System.out.println( "\nWriting to file " + fileName );
 
 		final ArrayList< InputTriggerDescription > keyMappings = new ArrayList< InputTriggerDescription >();
-		keyMappings.add( new InputTriggerDescription( "button1", "ts select vertex", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "button2", "ts select edge", "bdv", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "A", "navigate", "bdv", "trackscheme" ) );
-		keyMappings.add( new InputTriggerDescription( "B", "sleep", "" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "button1" }, "ts select vertex", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "button2" }, "ts select edge", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "A" }, "navigate", "bdv", "trackscheme" ) );
+		keyMappings.add( new InputTriggerDescription( new String[] { "B" }, "sleep", "" ) );
 		YamlConfigIO.write( keyMappings, "yamltest.txt" );
 
 		System.out.println( "\nContent of file:" );


### PR DESCRIPTION
Two important changes.
- Made the InputTriggerDescription a Bean, with setters and a blank constructor.
- If the user use "" for contexts, it is changed in a 0-length context array.
