### PR TITLE
Support for implementing package-external handlers

### DIFF
--- a/src/main/java/org/scijava/ui/behaviour/BehaviourMap.java
+++ b/src/main/java/org/scijava/ui/behaviour/BehaviourMap.java
@@ -127,7 +127,7 @@ public class BehaviourMap
 		return allBindings;
 	}
 
-	protected int modCount()
+	public int modCount()
 	{
 		if ( parent != null )
 		{

--- a/src/main/java/org/scijava/ui/behaviour/InputTrigger.java
+++ b/src/main/java/org/scijava/ui/behaviour/InputTrigger.java
@@ -24,11 +24,11 @@ import gnu.trove.set.hash.TIntHashSet;
  */
 public class InputTrigger
 {
-	static final int DOUBLE_CLICK_MASK = 1 << 20;
+	public static final int DOUBLE_CLICK_MASK = 1 << 20;
 
-	static final int SCROLL_MASK = 1 << 21;
+	public static final int SCROLL_MASK = 1 << 21;
 
-	static final int WIN_DOWN_MASK = 1 << 22;
+	public static final int WIN_DOWN_MASK = 1 << 22;
 
 	/**
 	 * Word to use to specify a double-click modifier.

--- a/src/main/java/org/scijava/ui/behaviour/InputTriggerMap.java
+++ b/src/main/java/org/scijava/ui/behaviour/InputTriggerMap.java
@@ -180,7 +180,7 @@ public class InputTriggerMap
 		return allBindings;
 	}
 
-	protected int modCount()
+	public int modCount()
 	{
 		if ( parent != null )
 		{


### PR DESCRIPTION
This commit introduces a few getters and makes some properties accessible, such that
external handlers (apart from Swing) may be implemented, such as JOGL or LWJGL.
In detail:
- _BehaviourMap_ and _InputTriggerMap_ gain a _modCount()_ getter
- the `_MASK` static properties of _InputTrigger_ are now public static
