### PR TITLE
Visual editor jtable additions

### DIFF
--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
@@ -306,6 +306,11 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 		return triggers;
 	}
 
+	void clear()
+	{
+		actionToInputsMap.clear();
+	}
+
 	void add( final String trigger, final String behaviourName, final String context )
 	{
 		add( InputTrigger.getFromString( trigger ), behaviourName, context );

--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerDescriptionsBuilder.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerDescriptionsBuilder.java
@@ -111,7 +111,7 @@ public class InputTriggerDescriptionsBuilder
 
 	public Set< String > getBehaviourNames()
 	{
-		return config.actionToInputsMap.keySet();
+		return new LinkedHashSet<>( config.actionToInputsMap.keySet() );
 	}
 
 	public void addMap( final InputTriggerMap map, final String context )

--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerDescriptionsBuilder.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerDescriptionsBuilder.java
@@ -32,10 +32,12 @@ package org.scijava.ui.behaviour.io;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import java.util.stream.Collectors;
 import javax.swing.InputMap;
 
 import org.scijava.ui.behaviour.InputTriggerMap;
@@ -96,6 +98,20 @@ public class InputTriggerDescriptionsBuilder
 		}
 
 		return descs;
+	}
+
+	public Set< String > getContexts()
+	{
+		final Set< String > contexts = new LinkedHashSet<>();
+		for ( final Entry< String, Set< Input > > entry : config.actionToInputsMap.entrySet() )
+			for ( final Input input : entry.getValue() )
+				contexts.addAll( input.contexts );
+		return contexts;
+	}
+
+	public Set< String > getBehaviourNames()
+	{
+		return config.actionToInputsMap.keySet();
 	}
 
 	public void addMap( final InputTriggerMap map, final String context )

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -9,6 +9,7 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.KeyboardFocusManager;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
@@ -332,6 +333,8 @@ public class VisualEditorPanel extends JPanel
 				updateEditors();
 			}
 		} );
+		tableBindings.setFocusTraversalKeys( KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, null );
+		tableBindings.setFocusTraversalKeys( KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, null );
 
 		// Listen to changes in the keybinding editor and forward to table model.
 		keybindingEditor.addInputTriggerChangeListener( () -> keybindingsChanged(

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -3,7 +3,6 @@ package org.scijava.ui.behaviour.io;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -13,7 +12,6 @@ import java.awt.KeyboardFocusManager;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -24,12 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -40,9 +36,6 @@ import javax.swing.JTextField;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
 import javax.swing.ScrollPaneConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
@@ -51,19 +44,18 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
-
 import org.scijava.ui.behaviour.InputTrigger;
 import org.scijava.ui.behaviour.io.InputTriggerConfig.Input;
 import org.scijava.ui.behaviour.io.gui.InputTriggerPanelEditor;
 import org.scijava.ui.behaviour.io.gui.TagPanelEditor;
-import org.scijava.ui.behaviour.io.yaml.YamlConfigIO;
 
 public class VisualEditorPanel extends JPanel
 {
 
 	private static final long serialVersionUID = 1L;
 
-	private static JFileChooser fileChooser = new JFileChooser();
+	static JFileChooser fileChooser = new JFileChooser();
+
 	static
 	{
 		fileChooser.setFileFilter( new FileFilter()
@@ -834,97 +826,4 @@ public class VisualEditorPanel extends JPanel
 			return o1.toString().compareTo( o2.toString() );
 		}
 	}
-
-	/*
-	 * DEMO METHODS.
-	 */
-
-	private static InputTriggerConfig getDemoConfig()
-	{
-		final StringReader reader = new StringReader( "---\n" +
-				"- !mapping" + "\n" +
-				"  action: fluke" + "\n" +
-				"  contexts: [all]" + "\n" +
-				"  triggers: [F]" + "\n" +
-				"- !mapping" + "\n" +
-				"  action: drag1" + "\n" +
-				"  contexts: [all]" + "\n" +
-				"  triggers: [button1, win G]" + "\n" +
-				"- !mapping" + "\n" +
-				"  action: scroll1" + "\n" +
-				"  contexts: [all]" + "\n" +
-				"  triggers: [scroll]" + "\n" +
-				"- !mapping" + "\n" +
-				"  action: scroll1" + "\n" +
-				"  contexts: [trackscheme, mamut]" + "\n" +
-				"  triggers: [shift D]" + "\n" +
-				"- !mapping" + "\n" +
-				"  action: destroy the world" + "\n" +
-				"  contexts: [unknown context, mamut]" + "\n" +
-				"  triggers: [control A]" + "\n" +
-				"" );
-		final List< InputTriggerDescription > triggers = YamlConfigIO.read( reader );
-		final InputTriggerConfig config = new InputTriggerConfig( triggers );
-		return config;
-	}
-
-	private static Map< String, String > getDemoActions()
-	{
-		final Map< String, String > actions = new HashMap<>();
-		actions.put( "drag1", "Move an item around the editor." );
-		actions.put( "scroll1", null );
-		actions.put( "destroy the world", "Make a disgusting coffee for breakfast. \n"
-				+ "For this one, you are by yourself. Good luck and know that we are with you. This is a long line. Hopefully long engouh.\n"
-				+ "Hey, what about we add:\n"
-				+ "tabulation1\ttabulation2\n"
-				+ "lalallala\ttrollololo." );
-		actions.put( "ride the dragon", "Go to work by bike." );
-		actions.put( "make some coffee", null );
-		return actions;
-	}
-
-	private static Set< String > getDemoContexts()
-	{
-		final Set< String > contexts = new HashSet<>();
-		contexts.add( "all" );
-		contexts.add( "mamut" );
-		contexts.add( "trackscheme" );
-		return contexts;
-	}
-
-	/**
-	 * Launch the application.
-	 *
-	 * @param args
-	 *
-	 * @throws UnsupportedLookAndFeelException
-	 * @throws IllegalAccessException
-	 * @throws InstantiationException
-	 * @throws ClassNotFoundException
-	 */
-	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException
-	{
-		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
-		EventQueue.invokeLater( new Runnable()
-		{
-			@Override
-			public void run()
-			{
-				try
-				{
-					final JFrame frame = new JFrame( "Behaviour Key bindings editor" );
-					final VisualEditorPanel editorPanel = new VisualEditorPanel( getDemoConfig(), getDemoActions(), getDemoContexts() );
-					SwingUtilities.updateComponentTreeUI( VisualEditorPanel.fileChooser );
-					frame.getContentPane().add( editorPanel );
-					frame.pack();
-					frame.setVisible( true );
-				}
-				catch ( final Exception e )
-				{
-					e.printStackTrace();
-				}
-			}
-		} );
-	}
-
 }

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -136,7 +136,7 @@ public class VisualEditorPanel extends JPanel
 		panelFilter.add( horizontalStrut );
 
 		final JLabel lblFilter = new JLabel( "Filter:" );
-		lblFilter.setToolTipText( "Fiter on command names. Accept regular expressions." );
+		lblFilter.setToolTipText( "Filter on command names. Accept regular expressions." );
 		lblFilter.setAlignmentX( Component.CENTER_ALIGNMENT );
 		panelFilter.add( lblFilter );
 

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -105,6 +105,10 @@ public class VisualEditorPanel extends JPanel
 
 	private JTextArea textAreaDescription;
 
+	private final JPanel panelEditor;
+
+	private final JPanel panelButtons;
+
 	/**
 	 * Creates a visual editor for an {@link InputTriggerConfig}. The config
 	 * object is directly modified when the user clicks the 'Apply' button.
@@ -169,7 +173,7 @@ public class VisualEditorPanel extends JPanel
 			}
 		} );
 
-		final JPanel panelEditor = new JPanel();
+		panelEditor = new JPanel();
 		add( panelEditor, BorderLayout.SOUTH );
 		panelEditor.setLayout( new BorderLayout( 0, 0 ) );
 
@@ -299,7 +303,7 @@ public class VisualEditorPanel extends JPanel
 		textAreaDescription.setLineWrap( true );
 		scrollPaneDescription.setViewportView( textAreaDescription );
 
-		final JPanel panelButtons = new JPanel();
+		panelButtons = new JPanel();
 		panelEditor.add( panelButtons, BorderLayout.SOUTH );
 		final FlowLayout flowLayout = ( FlowLayout ) panelButtons.getLayout();
 		flowLayout.setAlignment( FlowLayout.TRAILING );
@@ -388,7 +392,14 @@ public class VisualEditorPanel extends JPanel
 		}
 	}
 
-	private void modelToConfig()
+	public void setButtonPanelVisible( boolean visible )
+	{
+		panelEditor.remove( panelButtons );
+		if ( visible )
+			panelEditor.add( panelButtons, BorderLayout.SOUTH );
+	}
+
+	public void modelToConfig()
 	{
 		final HashMap< String, Set< Input > > actionToInputsMap = config.actionToInputsMap;
 		actionToInputsMap.clear();
@@ -411,7 +422,7 @@ public class VisualEditorPanel extends JPanel
 		}
 	}
 
-	private void configToModel()
+	public void configToModel()
 	{
 		tableModel = new MyTableModel( actionDescriptions.keySet(), config.actionToInputsMap );
 		tableBindings.setModel( tableModel );

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -333,7 +333,7 @@ public class VisualEditorPanel extends JPanel
 			}
 		} );
 
-		// Listen to changes in the
+		// Listen to changes in the keybinding editor and forward to table model.
 		keybindingEditor.addInputTriggerChangeListener( () -> keybindingsChanged(
 				keybindingEditor.getInputTrigger() == null
 						? keybindingEditor.getLastValidInputTrigger()

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -301,6 +301,7 @@ public class VisualEditorPanel extends JPanel
 		textAreaDescription.setWrapStyleWord( true );
 		textAreaDescription.setEditable( false );
 		textAreaDescription.setLineWrap( true );
+		textAreaDescription.setFocusable( false );
 		scrollPaneDescription.setViewportView( textAreaDescription );
 
 		panelButtons = new JPanel();

--- a/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/VisualEditorPanel.java
@@ -402,8 +402,7 @@ public class VisualEditorPanel extends JPanel
 
 	public void modelToConfig()
 	{
-		final HashMap< String, Set< Input > > actionToInputsMap = config.actionToInputsMap;
-		actionToInputsMap.clear();
+		config.clear();
 		for ( int i = 0; i < tableModel.commands.size(); i++ )
 		{
 			final InputTrigger inputTrigger = tableModel.bindings.get( i );
@@ -412,14 +411,16 @@ public class VisualEditorPanel extends JPanel
 
 			final String action = tableModel.commands.get( i );
 			final Set< String > cs = new HashSet<>( tableModel.contexts.get( i ) );
-			final Input input = new Input( inputTrigger, action, cs );
-			Set< Input > inputs = actionToInputsMap.get( action );
-			if ( null == inputs )
-			{
-				inputs = new HashSet<>();
-				actionToInputsMap.put( action, inputs );
-			}
-			inputs.add( input );
+			config.add( inputTrigger, action, cs );
+		}
+
+		// fill in InputTrigger.NOT_MAPPED for any action that doesn't have any input
+		for ( String context : contexts )
+		{
+			final Set< String > cs = Collections.singleton( context );
+			for ( String action : actionDescriptions.keySet() )
+				if ( config.getInputs( action, cs ).isEmpty() )
+					config.add( InputTrigger.NOT_MAPPED, action, cs );
 		}
 	}
 

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
@@ -150,6 +150,9 @@ public class InputTriggerPanelEditor extends JPanel
 
 		if ( null != properCapKey )
 		{
+			// Some tags are replaced for constructing the trigger, e.g., "cmd" is replaces by "meta"
+			properCapKey = INPUT_TRIGGER_SYNTAX_TAG_REMAP.getOrDefault( properCapKey, properCapKey );
+
 			// Try to append the key to the trigger.
 			final String str = ( null == trigger )
 					? invalidTriggerStr + " " + properCapKey
@@ -418,6 +421,8 @@ public class InputTriggerPanelEditor extends JPanel
 	private static final List< String > INPUT_TRIGGER_SYNTAX_TAGS = new ArrayList<>();
 	private static final List< String > INPUT_TRIGGER_SYNTAX_TAGS_SMALL_CAPS;
 	private static final Map< String, String > TRIGGER_SYMBOLS = new HashMap<>();
+	private static final Map<String, String> INPUT_TRIGGER_SYNTAX_TAG_REMAP = new HashMap<>();
+
 	static
 	{
 		for ( int i = 0; i < 26; i++ )
@@ -481,6 +486,8 @@ public class InputTriggerPanelEditor extends JPanel
 						"altGraph",
 						"shift",
 						"meta",
+						"command",
+						"cmd",
 						"win",
 						"double-click",
 						"button1",
@@ -493,6 +500,10 @@ public class InputTriggerPanelEditor extends JPanel
 		INPUT_TRIGGER_SYNTAX_TAGS_SMALL_CAPS = new ArrayList<>(INPUT_TRIGGER_SYNTAX_TAGS.size());
 		for ( final String tag : INPUT_TRIGGER_SYNTAX_TAGS )
 			INPUT_TRIGGER_SYNTAX_TAGS_SMALL_CAPS.add( tag.toLowerCase() );
+
+		INPUT_TRIGGER_SYNTAX_TAG_REMAP.put( "cmd", "meta" );
+		INPUT_TRIGGER_SYNTAX_TAG_REMAP.put( "command", "meta" );
+		INPUT_TRIGGER_SYNTAX_TAG_REMAP.put( "windows", "win" );
 
 		TRIGGER_SYMBOLS.put( "ENTER", "\u23CE" );
 		TRIGGER_SYMBOLS.put( "BACK_SPACE", "\u232B" );

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
@@ -3,6 +3,7 @@ package org.scijava.ui.behaviour.io.gui;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.KeyboardFocusManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -77,6 +78,8 @@ public class InputTriggerPanelEditor extends JPanel
 			textField.getDocument().addDocumentListener( autoComplete );
 			textField.getInputMap().put( KeyStroke.getKeyStroke( KeyEvent.VK_ENTER, 0 ), COMMIT_ACTION );
 			textField.getInputMap().put( KeyStroke.getKeyStroke( ' ' ), COMMIT_ACTION );
+			textField.setFocusTraversalKeys( KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet() );
+			textField.getInputMap().put( KeyStroke.getKeyStroke( KeyEvent.VK_TAB, 0 ), COMMIT_ACTION );
 			textField.getActionMap().put( COMMIT_ACTION, autoComplete.new CommitAction() );
 			textField.addKeyListener( new KeyAdapter()
 			{
@@ -346,6 +349,11 @@ public class InputTriggerPanelEditor extends JPanel
 			public void actionPerformed( final ActionEvent ev )
 			{
 				final String key = textField.getText().trim();
+				if ( key.isEmpty() )
+				{
+					KeyboardFocusManager.getCurrentKeyboardFocusManager().focusNextComponent();
+					return;
+				}
 				checkAndAppendKey( key );
 				textField.setText( "" );
 				notifyListeners();

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/InputTriggerPanelEditor.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.swing.AbstractAction;
@@ -533,10 +534,15 @@ public class InputTriggerPanelEditor extends JPanel
 		TRIGGER_SYMBOLS.put( "ctrl", "\u2303" );
 		TRIGGER_SYMBOLS.put( "alt", "\u2387" );
 		TRIGGER_SYMBOLS.put( "shift", "\u21e7" );
-		TRIGGER_SYMBOLS.put( "meta", "\u25c6" );
+		TRIGGER_SYMBOLS.put( "meta", isMac() ? "\u2318" : "\u25c6" );
 		TRIGGER_SYMBOLS.put( "win", "\u2756" );
 		// Vertical bar is special
 		TRIGGER_SYMBOLS.put( "|", "    |    " );
 	}
 
+	private static boolean isMac()
+	{
+		final String OS = System.getProperty( "os.name", "generic" ).toLowerCase( Locale.ENGLISH );
+		return ( OS.indexOf( "mac" ) >= 0 ) || ( OS.indexOf( "darwin" ) >= 0 );
+	}
 }

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/TagPanelEditor.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/TagPanelEditor.java
@@ -3,6 +3,7 @@ package org.scijava.ui.behaviour.io.gui;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.KeyboardFocusManager;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -89,6 +90,8 @@ public class TagPanelEditor extends JPanel
 			final Autocomplete autoComplete = new Autocomplete();
 			textField.getDocument().addDocumentListener( autoComplete );
 			textField.getInputMap().put( KeyStroke.getKeyStroke( KeyEvent.VK_ENTER, 0 ), COMMIT_ACTION );
+			textField.setFocusTraversalKeys( KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet() );
+			textField.getInputMap().put( KeyStroke.getKeyStroke( KeyEvent.VK_TAB, 0 ), COMMIT_ACTION );
 			textField.getActionMap().put( COMMIT_ACTION, autoComplete.new CommitAction() );
 			textField.addKeyListener( new KeyAdapter()
 			{
@@ -226,6 +229,13 @@ public class TagPanelEditor extends JPanel
 			public void actionPerformed( final ActionEvent ev )
 			{
 				final String tag = textField.getText();
+
+				if ( tag.isEmpty() )
+				{
+					KeyboardFocusManager.getCurrentKeyboardFocusManager().focusNextComponent();
+					return;
+				}
+
 				if ( selectedTags.contains( tag ) )
 				{
 					// Do not allow more than 1 tag instance.

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/TagPanelEditor.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/TagPanelEditor.java
@@ -243,9 +243,9 @@ public class TagPanelEditor extends JPanel
 
 		private class CompletionTask implements Runnable
 		{
-			private String completion;
+			private final String completion;
 
-			private int position;
+			private final int position;
 
 			CompletionTask( final String completion, final int position )
 			{
@@ -268,42 +268,56 @@ public class TagPanelEditor extends JPanel
 
 	final class TagPanel extends JPanel
 	{
-
 		private static final long serialVersionUID = 1L;
 
 		public TagPanel( final String tag, final boolean valid )
 		{
+			final Color bg = valid ? getBackground() : Color.PINK;
 			final Font font = TagPanelEditor.this.getFont().deriveFont( TagPanelEditor.this.getFont().getSize2D() - 2f );
+
+			final JPanel content = new JPanel();
+			content.setLayout( new BoxLayout( content, BoxLayout.LINE_AXIS ) );
+			content.setOpaque( true );
+			content.setBackground( bg );
+			content.setBorder( new RoundBorder( bg.darker(), TagPanelEditor.this, 1 ) );
+
+			if ( editable )
+			{
+				final JLabel close = new JLabel( "\u00D7" );
+				close.setFont( font );
+				close.setOpaque( false );
+				close.addMouseListener( new java.awt.event.MouseAdapter()
+				{
+					@Override
+					public void mousePressed( final java.awt.event.MouseEvent evt )
+					{
+						removeTag( tag );
+					}
+				} );
+				content.add( close );
+				content.add( createHorizontalStrutWithMaxHeight1( 2 ) );
+			}
+
 			final String str = printables.containsKey( tag ) ? printables.get( tag ) : tag;
 			final JLabel txt = new JLabel( str );
 			txt.setFont( font );
-			txt.setOpaque( true );
-			if ( !valid )
-				txt.setBackground( Color.PINK );
-			txt.setBorder( new RoundBorder( getBackground().darker(), TagPanelEditor.this, 3 ) );
-
-			final JLabel close = new JLabel( "\u00D7" );
-			close.setOpaque( true );
-			close.setBackground( getBackground().darker().darker() );
-			close.setFont( font );
-			close.addMouseListener( new java.awt.event.MouseAdapter()
-			{
-				@Override
-				public void mousePressed( final java.awt.event.MouseEvent evt )
-				{
-					removeTag( tag );
-				}
-			} );
+			txt.setOpaque( false );
+			content.add( txt );
 
 			setLayout( new BoxLayout( this, BoxLayout.LINE_AXIS ) );
-			if ( editable )
-				add( close );
 			add( Box.createHorizontalStrut( 1 ) );
-			add( txt );
+			add( content );
 			add( Box.createHorizontalStrut( 4 ) );
 			setOpaque( false );
 		}
 	}
+
+	private static Box.Filler createHorizontalStrutWithMaxHeight1( final int width )
+	{
+		return new Box.Filler( new Dimension( width, 0 ), new Dimension( width, 0 ),
+				new Dimension( width, 1 ) );
+	}
+
 
 	private void notifyListeners()
 	{

--- a/src/test/java/org/scijava/ui/behaviour/io/VisualEditorPanelDemo.java
+++ b/src/test/java/org/scijava/ui/behaviour/io/VisualEditorPanelDemo.java
@@ -1,0 +1,109 @@
+package org.scijava.ui.behaviour.io;
+
+import java.awt.EventQueue;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import org.scijava.ui.behaviour.io.yaml.YamlConfigIO;
+
+public class VisualEditorPanelDemo
+{
+	/*
+	 * DEMO METHODS.
+	 */
+
+	private static InputTriggerConfig getDemoConfig()
+	{
+		final StringReader reader = new StringReader( "---\n" +
+				"- !mapping" + "\n" +
+				"  action: fluke" + "\n" +
+				"  contexts: [all]" + "\n" +
+				"  triggers: [F]" + "\n" +
+				"- !mapping" + "\n" +
+				"  action: drag1" + "\n" +
+				"  contexts: [all]" + "\n" +
+				"  triggers: [button1, win G]" + "\n" +
+				"- !mapping" + "\n" +
+				"  action: scroll1" + "\n" +
+				"  contexts: [all]" + "\n" +
+				"  triggers: [scroll]" + "\n" +
+				"- !mapping" + "\n" +
+				"  action: scroll1" + "\n" +
+				"  contexts: [trackscheme, mamut]" + "\n" +
+				"  triggers: [shift D]" + "\n" +
+				"- !mapping" + "\n" +
+				"  action: destroy the world" + "\n" +
+				"  contexts: [unknown context, mamut]" + "\n" +
+				"  triggers: [control A]" + "\n" +
+				"" );
+		final List< InputTriggerDescription > triggers = YamlConfigIO.read( reader );
+		final InputTriggerConfig config = new InputTriggerConfig( triggers );
+		return config;
+	}
+
+	private static Map< String, String > getDemoActions()
+	{
+		final Map< String, String > actions = new HashMap<>();
+		actions.put( "drag1", "Move an item around the editor." );
+		actions.put( "scroll1", null );
+		actions.put( "destroy the world", "Make a disgusting coffee for breakfast. \n"
+				+ "For this one, you are by yourself. Good luck and know that we are with you. This is a long line. Hopefully long engouh.\n"
+				+ "Hey, what about we add:\n"
+				+ "tabulation1\ttabulation2\n"
+				+ "lalallala\ttrollololo." );
+		actions.put( "ride the dragon", "Go to work by bike." );
+		actions.put( "make some coffee", null );
+		return actions;
+	}
+
+	private static Set< String > getDemoContexts()
+	{
+		final Set< String > contexts = new HashSet<>();
+		contexts.add( "all" );
+		contexts.add( "mamut" );
+		contexts.add( "trackscheme" );
+		return contexts;
+	}
+
+	/**
+	 * Launch the application.
+	 *
+	 * @param args
+	 *
+	 * @throws UnsupportedLookAndFeelException
+	 * @throws IllegalAccessException
+	 * @throws InstantiationException
+	 * @throws ClassNotFoundException
+	 */
+	public static void main( final String[] args ) throws ClassNotFoundException, InstantiationException, IllegalAccessException, UnsupportedLookAndFeelException
+	{
+		UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
+		EventQueue.invokeLater( new Runnable()
+		{
+			@Override
+			public void run()
+			{
+				try
+				{
+					final JFrame frame = new JFrame( "Behaviour Key bindings editor" );
+					final VisualEditorPanel editorPanel = new VisualEditorPanel( getDemoConfig(), getDemoActions(), getDemoContexts() );
+					SwingUtilities.updateComponentTreeUI( VisualEditorPanel.fileChooser );
+					frame.getContentPane().add( editorPanel );
+					frame.pack();
+					frame.setVisible( true );
+				}
+				catch ( final Exception e )
+				{
+					e.printStackTrace();
+				}
+			}
+		} );
+	}
+}


### PR DESCRIPTION
* fixes some typos
* add Mac-specific symbols (⌘) and tags ("cmd" translates to "meta)
* make the context tags nicer (include the "×" to remove them into the `RoundedBorder`)
* focus handling: Shift-Tab/Tab in the bindings table move focus to previous/next component
* hiding restore/apply buttons if editor is embedded elsewhere
* revised `modelToConfig()` to use new `InputTriggerConfig` methods
* moved demo to separate class `VisualEditorPanelDemo`