### PR TITLE
Fix a bug preventing default keystrokes to be used for Actions.

### DIFF
--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
@@ -256,7 +256,7 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 					return;
 				}
 
-				for ( final InputTrigger trigger : triggers )
+				for ( final InputTrigger trigger : defaultKeyStrokes )
 				{
 					if ( trigger.isKeyStroke() )
 					{


### PR DESCRIPTION
Before this commit, many actions were not bound _e.g._ in TrackScheme3 if the key bindings were not defined in a config file. This caused plenty of messages such as 

```

Could not assign KeyStroke for "load settings". Nothing defined in InputTriggerConfig, and no default given.
Could not assign KeyStroke for "render settings". Nothing defined in InputTriggerConfig, and no default given.
Could not assign KeyStroke for "ts navigate to child". Nothing defined in InputTriggerConfig, and no default given.
Could not assign KeyStroke for "ts navigate to parent". Nothing defined in InputTriggerConfig, and no default given.
```

to appear in the console.