### PR TITLE
VisualEditorPanel: finer grain listeners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
 		<license.copyrightOwners>Max Planck Institute of Molecular Cell Biology
 and Genetics.</license.copyrightOwners>
 
+		<scijava-listeners.version>1.0.0-beta-3</scijava-listeners.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 	</properties>
@@ -112,6 +114,11 @@ and Genetics.</license.copyrightOwners>
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-listeners</artifactId>
+			<version>${scijava-listeners.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>
 			<artifactId>trove4j</artifactId>

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
@@ -126,7 +126,12 @@ public class VisualEditorPanel extends JPanel
 
 	private final JPanel panelButtons;
 
-	private final HashSet< ConfigChangeListener > listeners;
+	/**
+	 * Set of listeners that are triggered whenever any single item change in the GUI.
+	 * This, however, does not mean that the underlying {@link InputTriggerConfig} was
+	 * changed at all as the GUI is buffering changes until the "Apply" button is pressed.
+	 */
+	private final HashSet< ConfigChangeListener > itemChangedListeners;
 
 	private final JButton btnApply;
 
@@ -165,7 +170,7 @@ public class VisualEditorPanel extends JPanel
 		commandNameToAcceptableContexts = new HashMap<>();
 		for ( final Command command : commands )
 			commandNameToAcceptableContexts.computeIfAbsent( command.getName(), k -> new HashSet<>() ).add( command.getContext() );
-		this.listeners = new HashSet<>();
+		this.itemChangedListeners = new HashSet<>();
 
 		/*
 		 * GUI
@@ -797,7 +802,7 @@ public class VisualEditorPanel extends JPanel
 
 	private void notifyListeners()
 	{
-		for ( final ConfigChangeListener listener : listeners )
+		for ( final ConfigChangeListener listener : itemChangedListeners)
 			listener.configChanged();
 	}
 
@@ -815,12 +820,12 @@ public class VisualEditorPanel extends JPanel
 
 	public void addConfigChangeListener( final ConfigChangeListener listener )
 	{
-		listeners.add( listener );
+		itemChangedListeners.add( listener );
 	}
 
 	public void removeConfigChangeListener( final ConfigChangeListener listener )
 	{
-		listeners.remove( listener );
+		itemChangedListeners.remove( listener );
 	}
 
 	/*

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
@@ -131,14 +131,14 @@ public class VisualEditorPanel extends JPanel
 	 * This, however, does not mean that the underlying {@link InputTriggerConfig} was
 	 * changed at all as the GUI is buffering changes until the "Apply" button is pressed.
 	 */
-	private final HashSet< ConfigChangeListener > itemChangedListeners;
+	private final HashSet< ConfigChangeListener > configChangeListeners;
 
 	/**
 	 * Set of listeners that are triggered only when the "Apply" button is pressed,
 	 * which is precisely the moment when the current state/content of GUI is committed
 	 * to the underlying {@link InputTriggerConfig} via the ModelToConfig().
 	 */
-	private final HashSet< ConfigChangeListener > configChangedListeners;
+	private final HashSet< ConfigChangeListener > configCommittedListeners;
 
 	private final JButton btnApply;
 
@@ -177,8 +177,8 @@ public class VisualEditorPanel extends JPanel
 		commandNameToAcceptableContexts = new HashMap<>();
 		for ( final Command command : commands )
 			commandNameToAcceptableContexts.computeIfAbsent( command.getName(), k -> new HashSet<>() ).add( command.getContext() );
-		this.itemChangedListeners = new HashSet<>();
-		this.configChangedListeners = new HashSet<>();
+		this.configChangeListeners = new HashSet<>();
+		this.configCommittedListeners = new HashSet<>();
 
 		/*
 		 * GUI
@@ -543,7 +543,7 @@ public class VisualEditorPanel extends JPanel
 		btnApply.setEnabled( false );
 		btnRestore.setEnabled( false );
 
-		configChangedListeners.forEach( l -> l.configChanged() );
+		configCommittedListeners.forEach( l -> l.configChanged() );
 	}
 
 	public void configToModel()
@@ -812,8 +812,7 @@ public class VisualEditorPanel extends JPanel
 
 	private void notifyListeners()
 	{
-		for ( final ConfigChangeListener listener : itemChangedListeners)
-			listener.configChanged();
+		configChangeListeners.forEach( ConfigChangeListener::configChanged );
 	}
 
 	private static Map< Command, String > extractEmptyCommandDescriptions( final InputTriggerConfig keyconf )
@@ -829,33 +828,33 @@ public class VisualEditorPanel extends JPanel
 	}
 
 	/**
-	 * Please, see the documentation of {@link VisualEditorPanel#itemChangedListeners}
-	 * and {@link VisualEditorPanel#configChangedListeners} to understand when these
+	 * Please, see the documentation of {@link VisualEditorPanel#configChangeListeners}
+	 * and {@link VisualEditorPanel#configCommittedListeners} to understand when these
 	 * listeners are triggered. In short, these are triggered anytime a GUI item is changed.
 	 */
 	public void addConfigChangeListener( final ConfigChangeListener listener )
 	{
-		itemChangedListeners.add( listener );
+		configChangeListeners.add( listener );
 	}
 
 	public void removeConfigChangeListener( final ConfigChangeListener listener )
 	{
-		itemChangedListeners.remove( listener );
+		configChangeListeners.remove( listener );
 	}
 
 	/**
-	 * Please, see the documentation of {@link VisualEditorPanel#itemChangedListeners}
-	 * and {@link VisualEditorPanel#configChangedListeners} to understand when these
+	 * Please, see the documentation of {@link VisualEditorPanel#configChangeListeners}
+	 * and {@link VisualEditorPanel#configCommittedListeners} to understand when these
 	 * listeners are triggered. In short, these are triggered only when "Apply" button is pressed.
 	 */
 	public void addConfigCommittedListener( final ConfigChangeListener listener )
 	{
-		configChangedListeners.add( listener );
+		configCommittedListeners.add( listener );
 	}
 
 	public void removeConfigCommittedListener( final ConfigChangeListener listener )
 	{
-		configChangedListeners.remove( listener );
+		configCommittedListeners.remove( listener );
 	}
 
 	/*

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
@@ -133,6 +133,13 @@ public class VisualEditorPanel extends JPanel
 	 */
 	private final HashSet< ConfigChangeListener > itemChangedListeners;
 
+	/**
+	 * Set of listeners that are triggered only when the "Apply" button is pressed,
+	 * which is precisely the moment when the current state/content of GUI is committed
+	 * to the underlying {@link InputTriggerConfig} via the ModelToConfig().
+	 */
+	private final HashSet< ConfigChangeListener > configChangedListeners;
+
 	private final JButton btnApply;
 
 	private final JButton btnRestore;
@@ -171,6 +178,7 @@ public class VisualEditorPanel extends JPanel
 		for ( final Command command : commands )
 			commandNameToAcceptableContexts.computeIfAbsent( command.getName(), k -> new HashSet<>() ).add( command.getContext() );
 		this.itemChangedListeners = new HashSet<>();
+		this.configChangedListeners = new HashSet<>();
 
 		/*
 		 * GUI
@@ -534,6 +542,8 @@ public class VisualEditorPanel extends JPanel
 
 		btnApply.setEnabled( false );
 		btnRestore.setEnabled( false );
+
+		configChangedListeners.forEach( l -> l.configChanged() );
 	}
 
 	public void configToModel()
@@ -818,6 +828,11 @@ public class VisualEditorPanel extends JPanel
 		return commandDescriptions;
 	}
 
+	/**
+	 * Please, see the documentation of {@link VisualEditorPanel#itemChangedListeners}
+	 * and {@link VisualEditorPanel#configChangedListeners} to understand when these
+	 * listeners are triggered. In short, these are triggered anytime a GUI item is changed.
+	 */
 	public void addConfigChangeListener( final ConfigChangeListener listener )
 	{
 		itemChangedListeners.add( listener );
@@ -826,6 +841,21 @@ public class VisualEditorPanel extends JPanel
 	public void removeConfigChangeListener( final ConfigChangeListener listener )
 	{
 		itemChangedListeners.remove( listener );
+	}
+
+	/**
+	 * Please, see the documentation of {@link VisualEditorPanel#itemChangedListeners}
+	 * and {@link VisualEditorPanel#configChangedListeners} to understand when these
+	 * listeners are triggered. In short, these are triggered only when "Apply" button is pressed.
+	 */
+	public void addConfigCommittedListener( final ConfigChangeListener listener )
+	{
+		configChangedListeners.add( listener );
+	}
+
+	public void removeConfigCommittedListener( final ConfigChangeListener listener )
+	{
+		configChangedListeners.remove( listener );
 	}
 
 	/*

--- a/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanel.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -49,7 +47,6 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
-
 import org.scijava.listeners.Listeners;
 import org.scijava.ui.behaviour.InputTrigger;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
@@ -87,12 +84,12 @@ public class VisualEditorPanel extends JPanel
 	 * editor.
 	 */
 	@FunctionalInterface
-	public static interface ConfigChangeListener
+	public interface ConfigChangeListener
 	{
 		/**
 		 * Called when settings are changed in the visual editor.
 		 */
-		public void configChanged();
+		void configChanged();
 	}
 
 	private JTextField textFieldFilter;
@@ -484,9 +481,9 @@ public class VisualEditorPanel extends JPanel
 				{
 					final StringBuilder str = new StringBuilder();
 					str.append( tableModel.rows.get( i ).getName() );
-					str.append( " in " + overlappingContexts.get( 0 ) );
+					str.append( " in " ).append( overlappingContexts.get( 0 ) );
 					for ( int j = 1; j < overlappingContexts.size(); j++ )
-						str.append( ", " + overlappingContexts.get( j ) );
+						str.append( ", " ).append( overlappingContexts.get( j ) );
 
 					conflicts.add( str.toString() );
 				}
@@ -497,7 +494,7 @@ public class VisualEditorPanel extends JPanel
 		{
 			final StringBuilder str = new StringBuilder( conflicts.get( 0 ) );
 			for ( int i = 1; i < conflicts.size(); i++ )
-				str.append( "; " + conflicts.get( i ) );
+				str.append( "; " ).append( conflicts.get( i ) );
 			lblConflict.setText( str.toString() );
 		}
 	}
@@ -626,16 +623,14 @@ public class VisualEditorPanel extends JPanel
 			{
 				sb.append( contexts.get( 0 ) );
 				for ( int j = 1; j < contexts.size(); j++ )
-					sb.append( " - " + contexts.get( j ) );
+					sb.append( " - " ).append( contexts.get( j ) );
 			}
 			sb.append( '\n' );
 		}
 
-		try (final PrintWriter pw = new PrintWriter( file ))
+		try ( final PrintWriter pw = new PrintWriter( file ) )
 		{
-
 			pw.write( sb.toString() );
-			pw.close();
 		}
 		catch ( final FileNotFoundException e )
 		{
@@ -675,9 +670,9 @@ public class VisualEditorPanel extends JPanel
 			{
 				final String d = actionDescriptions.get( new Command( action, context ) );
 				if ( d != null )
-					str.append( "\n\nIn " + context + ":\n" + d );
+					str.append( "\n\nIn " ).append( context ).append( ":\n" ).append( d );
 				else
-					str.append( "\n\nIn " + context + " - no description." );
+					str.append( "\n\nIn " ).append( context ).append( " - no description." );
 			}
 			str.delete( 0, 2 );
 			description = str.toString();
@@ -714,13 +709,7 @@ public class VisualEditorPanel extends JPanel
 			return;
 		final int modelRow = tableBindings.convertRowIndexToModel( viewRow );
 		final String removeName = tableModel.rows.get( modelRow ).getName();
-		final Iterator< MyTableRow > iter = tableModel.rows.iterator();
-		while( iter.hasNext() )
-		{
-			final MyTableRow row = iter.next();
-			if ( row.getName().equals( removeName ) )
-				iter.remove();
-		}
+		tableModel.rows.removeIf( row -> row.getName().equals( removeName ) );
 		if ( !tableModel.addMissingRows() )
 			tableModel.fireTableDataChanged();
 
@@ -1029,13 +1018,7 @@ public class VisualEditorPanel extends JPanel
 		 */
 		public void removeAllNotMapped( final List< MyTableRow > rows )
 		{
-			final Iterator< MyTableRow > iter = rows.iterator();
-			while ( iter.hasNext() )
-			{
-				final MyTableRow row = iter.next();
-				if ( row.getTrigger().equals( InputTrigger.NOT_MAPPED ) )
-					iter.remove();
-			}
+			rows.removeIf( row -> row.getTrigger().equals( InputTrigger.NOT_MAPPED ) );
 		}
 
 		/**

--- a/src/test/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanelDemo.java
+++ b/src/test/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanelDemo.java
@@ -91,7 +91,7 @@ public class VisualEditorPanelDemo
 				{
 					final JFrame frame = new JFrame( "Behaviour Key bindings editor" );
 					final VisualEditorPanel editorPanel = new VisualEditorPanel( getDemoConfig(), getDemoCommands() );
-					editorPanel.addConfigChangeListener( () -> System.out.println( "Config changed @ " + new java.util.Date().toString() ) );
+					editorPanel.configChangeListeners().add( () -> System.out.println( "Config changed @ " + new java.util.Date().toString() ) );
 					SwingUtilities.updateComponentTreeUI( VisualEditorPanel.fileChooser );
 					frame.getContentPane().add( editorPanel );
 					frame.pack();

--- a/src/test/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanelDemo.java
+++ b/src/test/java/org/scijava/ui/behaviour/io/gui/VisualEditorPanelDemo.java
@@ -45,8 +45,7 @@ public class VisualEditorPanelDemo
 				"  triggers: [control A]" + "\n" +
 				"" );
 		final List< InputTriggerDescription > triggers = YamlConfigIO.read( reader );
-		final InputTriggerConfig config = new InputTriggerConfig( triggers );
-		return config;
+		return new InputTriggerConfig( triggers );
 	}
 
 	private static Map< Command, String > getDemoCommands()


### PR DESCRIPTION
Hi,
I propose to add another layer of listeners into the `VisualEditorPanel`, and to rename to original ones (without breaking public API).

The original ones (renamed now into `itemChangedListeners`) were triggered everytime an item was changed in the GUI and were *not* triggered when the "Apply" button was pressed. The user-land code was therefore updated incrementally about *a presence of change* (no details about the change per se were provided via the listener notification **1**) and had to rescan somehow the GUI to find the change and update its own data. The user-land code never learnt that "apply" was pressed, so how should the code learn what has been changed and when to take these changes seriously?

**1**: Would be nice if the listeners would hear what triggered them -- what has been just changed. but we either break the API (by introducing param to the listeners) or create yet another type of listeners

The added listeners layer (`configChangedListeners`) is triggered only when "Apply" button is used, so they know that now is the right time to process the underlying `InputTriggerConfig` to readout the fresh new wanted state of key bindings...
(or I just totally misunderstood the whole thing......)

Cheers,
Vlado