### PR TITLE
Pr behaviours pretty printing

### DIFF
--- a/src/main/java/org/scijava/ui/behaviour/BehaviourMap.java
+++ b/src/main/java/org/scijava/ui/behaviour/BehaviourMap.java
@@ -30,7 +30,7 @@
 package org.scijava.ui.behaviour;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.TreeSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -160,7 +160,7 @@ public class BehaviourMap
 
 	public synchronized Set< String > keys()
 	{
-		return new HashSet<>( behaviours.keySet() );
+		return new TreeSet<>( behaviours.keySet() );
 	}
 
 	public int modCount()

--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Iterator;
 
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
@@ -107,6 +108,22 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 					triggers.add( input.trigger );
 		}
 		return triggers;
+	}
+
+	/**
+	 * Creates a pretty printed list of keys, useful in conjuction with {@link InputTriggerConfig#getInputs}.
+	 *
+	 * @param triggers Set of triggers to be printed.
+	 * @return String with formatted content.
+	 */
+	public static String prettyPrintInputs(final Set<InputTrigger> triggers) {
+		final StringBuilder sb = new StringBuilder();
+		final Iterator<InputTrigger> it = triggers.iterator();
+		while (it.hasNext()) {
+			sb.append( it.next() );
+			if (it.hasNext()) sb.append(" or ");
+		}
+		return sb.toString();
 	}
 
 	public void clear()


### PR DESCRIPTION
HI,
here's a util-kind-of PR:

- `BehaviourMap` lists string keys sorted
- `InputTriggerConfig` has a pretty printing static method (to obtain, e.g., "X or J" instead of "[X, J]" when printing the outcome of `getInputs()`

Example use case:
```
//behaviourMap and config defined outside
behaviourMap.keys().forEach( (s) -> {
                    System.out.print(s+" maps to: ");
                    System.out.println( InputTriggerConfig.prettyPrintInputs( config.getInputs(s,"all") )
} );
```