### PR TITLE
ADD: InputTriggerConfig.remove(...) ...

### DIFF
--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
@@ -149,7 +149,11 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 				 */
 				input.contexts.addAll( contexts );
 				return;
-				//NB: this assumes that there exists up to one Input record for this (trigger,behaviour) pair
+				/*
+				 * NB: this assumes that there exists not more than one Input
+				 * record for each (trigger, behaviour) pair. This property is
+				 * maintained by the add/remove implementations.
+				 */
 			}
 		}
 
@@ -173,32 +177,31 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 	public synchronized void remove( final InputTrigger trigger, final String behaviourName, final Collection< String > contexts )
 	{
 		final Set< Input > inputs = actionToInputsMap.get( behaviourName );
-		if (inputs == null) return;
+		if ( inputs == null )
+			return;
 
-		//find Input that covers this trigger -> behaviour binding
-		Input foundRelevantInput = null;
 		for ( final Input input : inputs )
 		{
 			if ( input.trigger.equals( trigger ) )
 			{
-				foundRelevantInput = input;
-				break;
-				//NB: this assumes that there exists up to one Input record for this (trigger,behaviour) pair
-			}
-		}
+				// found Input that covers this trigger -> behaviour binding,
+				// make sure it does not exist for the given context(s)
+				input.contexts.removeAll( contexts );
+				if ( input.contexts.isEmpty() )
+				{
+					// empty context set -> invalid record -> remove it
+					inputs.remove( input );
 
-		if (foundRelevantInput != null)
-		{
-			//found Input that covers this trigger -> behaviour binding,
-			//make sure it does not exist for the given context(s)
-			foundRelevantInput.contexts.removeAll( contexts );
-			if (foundRelevantInput.contexts.isEmpty())
-			{
-				//empty context set -> invalid record -> remove it
-				inputs.remove( foundRelevantInput );
+					if ( inputs.isEmpty() )
+						actionToInputsMap.remove( behaviourName );
+				}
 
-				if (inputs.isEmpty())
-					actionToInputsMap.remove( behaviourName );
+				return;
+				/*
+				 * NB: this assumes that there exists not more than one Input
+				 * record for each (trigger, behaviour) pair. This property is
+				 * maintained by the add/remove implementations.
+				 */
 			}
 		}
 	}

--- a/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/InputTriggerConfig.java
@@ -114,10 +114,10 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 		actionToInputsMap.clear();
 	}
 
-	public void set( InputTriggerConfig config )
+	public void set( final InputTriggerConfig config )
 	{
 		actionToInputsMap.clear();
-		for ( Entry< String, Set< Input > > entry : config.actionToInputsMap.entrySet() )
+		for ( final Entry< String, Set< Input > > entry : config.actionToInputsMap.entrySet() )
 		{
 			final String behaviourName = entry.getKey();
 			final Set< Input > inputs = new LinkedHashSet<>();
@@ -427,7 +427,7 @@ public class InputTriggerConfig implements InputTriggerAdder.Factory, KeyStrokeA
 			this.contexts = new HashSet<>( contexts );
 		}
 
-		Input( Input input )
+		Input( final Input input )
 		{
 			this.trigger = input.trigger;
 			this.behaviour = input.behaviour;


### PR DESCRIPTION
…  so that config items need not be only `add(...)`ed

This shall foster runtime adding and mainly *removing* of Behaviors (as opposed to statically predefining all of them, and possibly disabling some at runtime) without re-creating the `InputTriggerConfig` to match its associated `InputTriggerMap` (which *has* `remove()` methods).

