### PR TITLE
snakeyaml 2.0 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>34.1.0</version>
+		<version>36.0.0</version>
+		<relativePath />
 	</parent>
 
 	<artifactId>ui-behaviour</artifactId>
@@ -102,6 +103,8 @@ and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<snakeyaml.version>2.0</snakeyaml.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/org/scijava/ui/behaviour/io/yaml/YamlConfigIO.java
+++ b/src/main/java/org/scijava/ui/behaviour/io/yaml/YamlConfigIO.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import org.scijava.ui.behaviour.io.InputTriggerDescription;
 import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -86,14 +87,17 @@ public class YamlConfigIO
 	 */
 	private static final Yaml getYaml()
 	{
-		final Representer representer = new Representer();
-		representer.addClassTag( InputTriggerDescription.class, tag );
-
-		final Constructor constructor = new Constructor();
-		constructor.addTypeDescription( new TypeDescription( InputTriggerDescription.class, tag ) );
-
 		final DumperOptions options = new DumperOptions();
 		options.setExplicitStart( true );
+
+		final Representer representer = new Representer( options );
+		representer.addClassTag( InputTriggerDescription.class, tag );
+
+		final LoaderOptions loaderOptions = new LoaderOptions();
+
+		final Constructor constructor = new Constructor( loaderOptions );
+		constructor.addTypeDescription( new TypeDescription( InputTriggerDescription.class, tag ) );
+
 
 		final Yaml yaml = new Yaml( constructor, representer, options );
 		return yaml;


### PR DESCRIPTION
This PR does the following:
* bumps scijava parent POM to 36.0.0
* set the snakeyaml version to 2.0 explicitly
* adjust the options given to `Representer()` and `Constructor()` in `YamlConfigIO` to reflect API changes in snakeyaml 2.0